### PR TITLE
Fix dotnet core 2 branch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir;Configuration">
+  <PropertyGroup>
+    <RepositoryRootDirectory>$(MSBuildThisFileDirectory)</RepositoryRootDirectory>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <OutputPath>$(RepositoryRootDirectory)\build\$(MSBuildProjectName)\$(Configuration)\bin\</OutputPath>
+    <BaseIntermediateOutputPath>$(RepositoryRootDirectory)\build\$(MSBuildProjectName)\$(Configuration)\obj\</BaseIntermediateOutputPath>
+    <_WatchTarget>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).dotnetwatch.g.targets</_WatchTarget>
+  </PropertyGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER 1
 # WORKDIR /app
 RUN mkdir /app
 COPY ./src/*.csproj /app
+COPY ./Directory.Build.props /
 WORKDIR /app
 RUN dotnet restore
 

--- a/src/WatchRunDocker.csproj
+++ b/src/WatchRunDocker.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <_WatchTarget>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).dotnetwatch.g.targets</_WatchTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
@@ -10,9 +11,6 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
-  <PropertyGroup>
-    <BaseIntermediateOutputPath>..\build\$(AssemblyName)\obj</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-  </PropertyGroup>
+   <!-- This is a temporary workaround suggested to handle a known issue with watcher -->
+   <Import Project="$(_WatchTarget)" Condition="Exists('$(_WatchTarget)')" />  
 </Project>


### PR DESCRIPTION
@alexsandro-xpt 

From my findings, the root cause of this issue was due to changing the `BaseIntermediateOutputPath` in a csproj. Seems that this break is intended functionality, and props like this more appropriately belong in a `props` file. [Discovered issue](https://github.com/dotnet/sdk/issues/1518#issuecomment-324820638)

There is [another workaround](https://github.com/dotnet/sdk/issues/1518#issuecomment-324638682) you can do directly in the csproj file, but I don't think that is repeatable. At least with this, if you wanted to pull down from a curl request or something, its less overhead to setup.

The `_WatchTarget` stuff is something I found also as an issue [with watcher](https://github.com/aspnet/DotNetTools/issues/244) in regards to output path changing, and implemented the fix.

Let me know your thoughts.